### PR TITLE
perf: Debounce progress state updates

### DIFF
--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -5,6 +5,7 @@ import StatusSubview from 'components/status-subview';
 import toNS from 'mongodb-ns';
 import get from 'lodash.get';
 import has from 'lodash.has';
+import debounce from 'lodash.debounce';
 
 const debug = require('debug')('mongodb-compass:stores:schema');
 
@@ -291,14 +292,16 @@ const configureStore = (options = {}) => {
           })
           .on('progress', () => {
             sampleCount ++;
-            const newProgress = Math.ceil(sampleCount / numSamples * 100);
-            this.updateStatus(newProgress);
-            if (newProgress > this.state.samplingProgress) {
-              this.setState({
-                samplingProgress: newProgress,
-                samplingTimeMS: new Date() - samplingStart
-              });
-            }
+            debounce(() => {
+              const newProgress = Math.ceil(sampleCount / numSamples * 100);
+              this.updateStatus(newProgress);
+              if (newProgress > this.state.samplingProgress) {
+                this.setState({
+                  samplingProgress: newProgress,
+                  samplingTimeMS: new Date() - samplingStart
+                });
+              }
+            }, 250);
           })
           .on('data', (data) => {
             schema = data;


### PR DESCRIPTION
`setState()` is called in the store for `each` document sampled to update the query bar status values. Debouncing state writes for progress at 250ms results in substantial performance improvement. The below is only for 12 documents in `stonington.places`.  On full samples of 1000 documents, such as `ships.shipwrecks`, the difference is more dramatic; ~3seconds down to ~1.5 secs.

Largest blocking loop before adding debounce: 286ms@3fps
![Screenshot 2019-08-06 13 43 50](https://user-images.githubusercontent.com/23074/62565493-e4fc1480-b854-11e9-854e-94cf19f88e7f.png)

Largest blocking loop after adding debounce: 171ms@6fps
![Screenshot 2019-08-06 13 44 31](https://user-images.githubusercontent.com/23074/62565543-00671f80-b855-11e9-9fa7-afedc54dba32.png)

