### PR TITLE
COMPASS-3928: Schema Analysis leaves UI artifacts on completion

### DIFF
--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -183,6 +183,11 @@ const configureStore = (options = {}) => {
         clearInterval(this.samplingTimer);
         this.samplingTimer = null;
       }
+
+      this.setState({
+        samplingTimeMS: 0
+      });
+
       if (this.samplingStream) {
         this.samplingStream.destroy();
         this.samplingStream = null;

--- a/test/renderer/store.spec.js
+++ b/test/renderer/store.spec.js
@@ -68,6 +68,16 @@ describe('Schema Store', () => {
     it('defaults the count to 0', () => {
       expect(store.state.count).to.equal(0);
     });
+
+    it('resets samplingTimeMS after stop', () => {
+      store.setState({
+        samplingTimeMS: 100
+      });
+
+      store.stopSampling();
+
+      expect(store.state.samplingTimeMS).to.equal(0);
+    });
   });
 
   context('when query change events are emitted', () => {


### PR DESCRIPTION
COMPASS-3928: Schema Analysis leaves UI artifacts on completion

## Description

When the sampling (`samplingTimeMS`) takes more than 3 seconds, a message with the progress of the operation is displayed and does not disappear.

The fix consists in resetting `samplingTimeMS` to 0 when the operation completes.

### Checklist

- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->
Maybe the test could be more functional and check the behaviour on onSuccess and onError, but no other similar tests existed.

Also I'm not sure if the logic of display / hide should revolve around `samplingTimeMS`, maybe the completion status is more appropriate/explicit, I went for the least amount of changes.

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
