### PR TITLE
fix: only show outdated warning when the query changes in another tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "link-plugin": "./scripts/link.sh",
     "unlink-plugin": "./scripts/unlink.sh",
     "prepublishOnly": "npm run compile",
-    "install": "node scripts/download-akzidenz.js"
+    "install": "node scripts/download-akzidenz.js",
+    "start-compass": "node scripts/run-in-compass.js"
   },
   "precommit": [
     "check"

--- a/scripts/run-in-compass.js
+++ b/scripts/run-in-compass.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-use-before-define */
+/* eslint-disable no-console */
+/* eslint-disable no-sync */
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+const os = require('os');
+
+const pluginPath = path.resolve(__dirname, '..');
+const compassPath = path.resolve(os.tmpdir(), 'run-in-compass', path.basename(pluginPath), 'compass');
+const compassRepo = 'https://github.com/mongodb-js/compass.git';
+
+function main() {
+  syncCompassMaster();
+  linkPlugin();
+  installDeps();
+  linkReact();
+  recompile();
+  startCompass();
+}
+
+function installDeps() {
+  execSync('npm install', {
+    cwd: compassPath,
+    stdio: 'inherit'
+  });
+}
+
+function linkPlugin() {
+  const compassPackageJsonPath = path.resolve(compassPath, 'package.json');
+  const compassPackageJson = JSON.parse(fs.readFileSync(compassPackageJsonPath, 'utf-8'));
+  const pluginPackageJsonPath = path.resolve(pluginPath, 'package.json');
+  const pluginPackageJson = JSON.parse(fs.readFileSync(pluginPackageJsonPath, 'utf-8'));
+
+  compassPackageJson.dependencies[pluginPackageJson.name] = `file:${pluginPath}`;
+
+  const pluginLoadPath = `node_modules/${pluginPackageJson.name}`;
+  const plugins = compassPackageJson.config.hadron.distributions.compass.plugins;
+
+  if (!plugins.includes(pluginLoadPath)) {
+    plugins.push(pluginLoadPath);
+  }
+
+  fs.writeFileSync(compassPackageJsonPath, JSON.stringify(compassPackageJson));
+}
+
+function syncCompassMaster() {
+  if (!directoryExists(compassPath)) {
+    return cloneCompass();
+  }
+
+  resetCompass();
+}
+
+function resetCompass() {
+  if (!directoryExists(compassPath)) {
+    return;
+  }
+
+  execSync('git checkout master', { cwd: compassPath });
+  execSync('git fetch', { cwd: compassPath });
+  execSync('git reset --hard origin/master', { cwd: compassPath });
+}
+
+function cloneCompass() {
+  console.log(`Cloning compass master to ${compassPath}`);
+  execSync(`git clone ${compassRepo} ${compassPath}`);
+}
+
+function startCompass() {
+  execSync('npm run start', {
+    cwd: compassPath,
+    stdio: 'inherit'
+  });
+}
+
+function recompile() {
+  execSync('npm run compile', {
+    cwd: pluginPath,
+    stdio: 'inherit'
+  });
+}
+
+function directoryExists(directoryPath) {
+  return fs.existsSync(directoryPath) && fs.lstatSync(directoryPath).isDirectory();
+}
+
+function linkReact() {
+  const compassReactPath = path.resolve(compassPath, 'node_modules', 'react');
+
+  if (!directoryExists(compassReactPath)) {
+    return;
+  }
+
+  const pluginReactPath = path.resolve(pluginPath, 'node_modules', 'react');
+
+  if (fs.existsSync(pluginReactPath)) {
+    execSync(`rm -Rf ${pluginReactPath}`);
+  }
+
+  fs.symlinkSync(compassReactPath, pluginReactPath);
+}
+
+main();

--- a/src/constants/plugin.js
+++ b/src/constants/plugin.js
@@ -1,0 +1,1 @@
+export const TAB_NAME = 'Schema';

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,14 @@
 import CompassSchemaPlugin from './plugin';
 import configureStore from 'stores';
 import configureActions from 'actions';
+import { TAB_NAME } from './constants/plugin';
 
 /**
  * A sample role for the component.
  */
 const ROLE = {
   component: CompassSchemaPlugin,
-  name: 'Schema',
+  name: TAB_NAME,
   hasQueryHistory: true,
   order: 3,
   configureStore: configureStore,

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -11,6 +11,7 @@ import {
   ANALYSIS_STATE_INITIAL,
   ANALYSIS_STATE_TIMEOUT
 } from '../constants/analysis-states';
+import { TAB_NAME } from '../constants/plugin';
 
 const debug = require('debug')('mongodb-compass:stores:schema');
 
@@ -108,6 +109,7 @@ const configureStore = (options = {}) => {
       };
       this.ns = '';
       this.geoLayers = {};
+      this.isActiveTab = false;
     },
 
     getShareText() {
@@ -147,11 +149,18 @@ const configureStore = (options = {}) => {
       this.query.project = state.project;
       this.query.maxTimeMS = state.maxTimeMS;
 
-      if (this.state.analysisState === ANALYSIS_STATE_COMPLETE) {
+      if (
+        this.state.analysisState === ANALYSIS_STATE_COMPLETE &&
+        !this.isActiveTab
+      ) {
         this.setState({
           outdated: true
         });
       }
+    },
+
+    onSubTabChanged: function(name) {
+      this.isActiveTab = name === TAB_NAME;
     },
 
     onSchemaSampled() {
@@ -265,6 +274,10 @@ const configureStore = (options = {}) => {
 
   // Set the app registry if preset. This must happen first.
   if (options.localAppRegistry) {
+    options.localAppRegistry.on('subtab-changed', (name) => {
+      store.onSubTabChanged(name);
+    });
+
     /**
      * When the collection is changed, update the store.
      */


### PR DESCRIPTION
This avoid the banner to quickly flash on the screen before the sampling starts
